### PR TITLE
include otp 17 in rebar require_otp_version directive

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
 {cover_print_enabled, true}.
 {eunit_opts, [verbose]}.
 
-{require_otp_vsn, "R15|R16"}.
+{require_otp_vsn, "R15|R16|17"}.
 {clean_files, ["*~","*/*~","*/*.xfm","test/*.beam"]}.


### PR DESCRIPTION
Barrel seems to work without issue on OTP 17. 
